### PR TITLE
Ansible version bump

### DIFF
--- a/CloudFormation/AMI-Pipeline-Auto-Replace.yml
+++ b/CloudFormation/AMI-Pipeline-Auto-Replace.yml
@@ -243,7 +243,9 @@ Resources:
                       if [ "$ID" = "amzn" ]; then
                         if [ "$VERSION_ID" = "2" ]; then
                           echo "Installing Ansible on Amazon Linux 2..."
-                          sudo amazon-linux-extras install ansible2 -y
+                          sudo python3 -m pip install wheel
+                          sudo python3 -m pip install ansible
+                          sudo python3 -m pip install jmespath
                           git clone https://github.com/ansible-lockdown/AMAZON2-CIS.git /ansible/roles/AMAZON-CIS
                         elif [ "$VERSION_ID" = "2023" ]; then
                           echo "Installing Ansible on Amazon Linux 2023..."


### PR DESCRIPTION
Modified Ansible installation on AL2 due to incompatibility between the AL2 extras Ansible and newest updates of Ansible Lockdown role. Ansible is now installed using pip to install v2.11

*Issue #, if available:*
#2 

*Description of changes:*
Changes Ansible installation method from AL2 extras to Python3 pip.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
