### PR TITLE
Fixing node group info lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This repository contains a CloudFormation template that automates the creation o
 > [!IMPORTANT]
 > Applying all CIS benchmarks to your base image cases EC2 Image Builder pipeline to fail, and prevents your nodes from joining the cluster. At a minimum, you need to pass below values as your template's `AnsiblePlaybookArguments` parameter value.
 >
-> Amazon Linux 2: `--extra-vars '{"amazon2cis_firewall":"external"}' --skip-tags rule_6.2.11,rule_6.2.12,rule_6.2.13,rule_6.2.14,rule_6.2.15,rule_6.2.16,rule_6.2.17`
+> Amazon Linux 2: `--extra-vars '{"amazon2cis_firewall":"external","amazon2cis_rule_4_5_2_4":false}' --skip-tags rule_6.2.11,rule_6.2.12,rule_6.2.13,rule_6.2.14,rule_6.2.15,rule_6.2.16,rule_6.2.17,rule_4.5.2.4`
 >
 > Amazon Linux 2023: `--extra-vars '{"amzn2023cis_syslog_service":"external","amzn2023cis_selinux_disable":"true"}' --skip-tags rule_1.1.2.3,rule_1.1.4.3,rule_1.2.1,rule_1.3.1,rule_1.3.3,firewalld,accounts,logrotate,rule_6.2.10`
 >

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This repository contains a CloudFormation template that automates the creation o
 >
 > Amazon Linux 2: `--extra-vars '{"amazon2cis_firewall":"external","amazon2cis_rule_4_5_2_4":false}' --skip-tags rule_6.2.11,rule_6.2.12,rule_6.2.13,rule_6.2.14,rule_6.2.15,rule_6.2.16,rule_6.2.17,rule_4.5.2.4`
 >
-> Amazon Linux 2023: `--extra-vars '{"amzn2023cis_syslog_service":"external","amzn2023cis_selinux_disable":"true"}' --skip-tags rule_1.1.2.3,rule_1.1.4.3,rule_1.2.1,rule_1.3.1,rule_1.3.3,firewalld,accounts,logrotate,rule_6.2.10`
+> Amazon Linux 2023: `--extra-vars '{"amzn2023cis_syslog_service":"external","amzn2023cis_selinux_disable":true}' --skip-tags rule_1.1.2.3,rule_1.1.4.3,rule_1.2.1,rule_1.3.1,rule_1.3.3,firewalld,accounts,logrotate,rule_6.2.10`
 >
 > View [AMAZON2-CIS](https://github.com/ansible-lockdown/AMAZON2-CIS/blob/main/defaults/main.yml) and [AMAZON2023-CIS](https://github.com/ansible-lockdown/AMAZON2023-CIS/blob/main/defaults/main.yml) for a list of available variables for AL2 and AL2023 base images respectively.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository contains a CloudFormation template that automates the creation o
 | `DistributionConfigurationName` | EC2 Image builder distribution configuration name |
 | `ImagePipelineName` | EC2 Image builder pipeline name |
 | `EnableImageScanning` | Toggle for Amazon Inspector AMI scanning. |
-| `ClusterTags` | JSON string of key-value pairs to filter EKS clusters. |
+| `ClusterTags` | JSON string of key-value pairs to filter EKS clusters. Example: `[{"Key": "Team", "Value": "Development"}]` |
 | `CloudFormationUpdaterEventBridgeRuleState` | State of the EventBridge rule for weekend checks on new base images. |
 
 > [!IMPORTANT]


### PR DESCRIPTION
*Issue #, if available:*
#2 

*Description of changes:*
Node group info lambda was updated to properly handle EKS cluster tags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
